### PR TITLE
add skip_destroy option to publish_draft!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea

--- a/lib/activerecord_instance_methods.rb
+++ b/lib/activerecord_instance_methods.rb
@@ -55,7 +55,7 @@ module DraftPunk
       # again on the approved object.
       # 
       # @return [ActiveRecord Object] updated version of the approved object
-      def publish_draft!
+      def publish_draft! skip_destroy: false
         @live_version  = get_approved_version
         @draft_version = editable_version
         return unless changes_require_approval? && @draft_version.is_draft? # No-op. ie. the business is in a state that doesn't require approval.
@@ -63,7 +63,7 @@ module DraftPunk
         transaction do
           save_attribute_changes_and_belongs_to_assocations_from_draft
           update_has_many_and_has_one_associations_from_draft
-          @live_version.draft.destroy # We have to do this since we moved all the draft's has_many associations to @live_version. If you call "editable_version" later, it'll build the draft.
+          @live_version.draft.destroy unless skip_destroy # We have to do this since we moved all the draft's has_many associations to @live_version. If you call "editable_version" later, it'll build the draft.
         end
         @live_version = self.class.find(@live_version.id)
       end


### PR DESCRIPTION
Hi. My usecase requires to store both objects(draft and approved) at the same time. So when I copy changes from draft to approved I need draft object to persist. Do you think its ok to add this option? 

Also there were some tests failing. Not sure if I fixed the properly. 