### PR TITLE
move before_create_draft from after_create callback

### DIFF
--- a/lib/activerecord_class_methods.rb
+++ b/lib/activerecord_class_methods.rb
@@ -160,7 +160,6 @@ module DraftPunk
       def setup_associations_and_scopes_for(target_class, set_default_scope: false)
         target_class.send       :include, InstanceInterrogators unless target_class.method_defined?(:has_draft?)
         target_class.send       :attr_accessor, :temporary_approved_object
-        target_class.send       :before_create, :before_create_draft if target_class.method_defined?(:before_create_draft)
 
         return if target_class.reflect_on_association(:approved_version) || !target_class.column_names.include?('approved_version_id')
         target_class.send       :include, ActiveRecordInstanceMethods

--- a/lib/activerecord_instance_methods.rb
+++ b/lib/activerecord_instance_methods.rb
@@ -41,6 +41,11 @@ module DraftPunk
       def after_create_draft
       end
 
+      # Evaluates before the draft is created.
+      # Override in your model to implement custom behavior.
+      def before_create_draft
+      end
+
       #############################
       # END CONFIGURABLE METHODS
       #############################
@@ -98,6 +103,7 @@ module DraftPunk
         dupe = amoeba_dup
         begin
           dupe.approved_version = self
+          dupe.before_create_draft
           dupe.save(validate: false)
           dupe.after_create_draft
         rescue => message

--- a/spec/instance_methods_spec.rb
+++ b/spec/instance_methods_spec.rb
@@ -192,6 +192,21 @@ describe DraftPunk::Model::ActiveRecordInstanceMethods do
 
   end
 
+  context :before_create_draft do
+    before(:each) do
+      House.send(:define_method, 'before_create_draft') do
+        self.architectual_style = 'Borocco'
+      end
+      setup_model_approvals
+      setup_house_with_draft
+    end
+
+    it "modifies the draft object per the after_create_draft when a draft is created" do
+      expect(@house.architectual_style).to eq 'Ranch'
+      expect(@draft.architectual_style).to eq 'Borocco'
+    end
+  end
+
   context :after_create_draft do
     before(:each) do
       House.send(:define_method, 'after_create_draft') do


### PR DESCRIPTION
having this callback as `before_create` triggers it for creation of regular objects(not drafts)
Plus it failed for me with STI. My children classes defined `before_create_draft ` method, but callback was trying to set up in base class. And base class didn't have `before_create_draft `